### PR TITLE
Fix JSON tags

### DIFF
--- a/service.go
+++ b/service.go
@@ -78,7 +78,7 @@ type WorkspaceClientCapabilities struct {
 	Symbol struct {
 		SymbolKind struct {
 			ValueSet []int `json:"valueSet,omitempty"`
-		} `json:"symbolKind,omitEmpty"`
+		} `json:"symbolKind,omitempty"`
 	} `json:"symbol,omitempty"`
 
 	ExecuteCommand *struct {
@@ -122,7 +122,7 @@ type TextDocumentClientCapabilities struct {
 	DocumentSymbol struct {
 		SymbolKind struct {
 			ValueSet []int `json:"valueSet,omitempty"`
-		} `json:"symbolKind,omitEmpty"`
+		} `json:"symbolKind,omitempty"`
 
 		HierarchicalDocumentSymbolSupport bool `json:"hierarchicalDocumentSymbolSupport,omitempty"`
 	} `json:"documentSymbol,omitempty"`
@@ -723,8 +723,8 @@ type DidChangeTextDocumentParams struct {
 }
 
 type TextDocumentContentChangeEvent struct {
-	Range       *Range `json:"range,omitEmpty"`
-	RangeLength uint   `json:"rangeLength,omitEmpty"`
+	Range       *Range `json:"range,omitempty"`
+	RangeLength uint   `json:"rangeLength,omitempty"`
 	Text        string `json:"text"`
 }
 


### PR DESCRIPTION
This fixes JSON `omitempty` tags that were incorrectly set with the similar but do-nothing tag `omitEmpty`.